### PR TITLE
fix: make navigation wrap on smaller devices

### DIFF
--- a/content/_includes/breadcrumbs.njk
+++ b/content/_includes/breadcrumbs.njk
@@ -1,5 +1,5 @@
 <nav>
-	<ol role="list" class="flex items-center">
+	<ol role="list" class="flex flex-wrap items-center">
 		{% if crumbs.length > 0 %}
 			<li class="text-md lowercase after:text-f-med after:mx-[1ch] after:content-['/']"><a href="/" class="focus:underline focus:outline-none">mellow</a></li>
 		{% else %}

--- a/content/_includes/layouts/base.njk
+++ b/content/_includes/layouts/base.njk
@@ -30,7 +30,7 @@ locale: en
 
 		<header class="mt-page-top sticky top-0 z-20 h-header-height">
 			<div
-				class="flex flex-wrap h-header-height w-full items-center px-page-gutter before:absolute before:inset-0 before:z-[-1] before:bg-b-low [@supports(backdrop-filter:blur(0))]:before:bg-b-low-a [@supports(backdrop-filter:blur(0))]:before:backdrop-blur-md"
+				class="flex h-header-height w-full items-center px-page-gutter before:absolute before:inset-0 before:z-[-1] before:bg-b-low [@supports(backdrop-filter:blur(0))]:before:bg-b-low-a [@supports(backdrop-filter:blur(0))]:before:backdrop-blur-md"
 			>
 				<div class="mx-auto flex w-full max-w-content items-center">
 					{% include "breadcrumbs.njk" %}

--- a/content/_includes/layouts/base.njk
+++ b/content/_includes/layouts/base.njk
@@ -30,7 +30,7 @@ locale: en
 
 		<header class="mt-page-top sticky top-0 z-20 h-header-height">
 			<div
-				class="flex h-header-height w-full items-center px-page-gutter before:absolute before:inset-0 before:z-[-1] before:bg-b-low [@supports(backdrop-filter:blur(0))]:before:bg-b-low-a [@supports(backdrop-filter:blur(0))]:before:backdrop-blur-md"
+				class="flex flex-wrap h-header-height w-full items-center px-page-gutter before:absolute before:inset-0 before:z-[-1] before:bg-b-low [@supports(backdrop-filter:blur(0))]:before:bg-b-low-a [@supports(backdrop-filter:blur(0))]:before:backdrop-blur-md"
 			>
 				<div class="mx-auto flex w-full max-w-content items-center">
 					{% include "breadcrumbs.njk" %}


### PR DESCRIPTION
I took inspiration from your navigation on your site, but had an issue with longer posts:
![image](https://github.com/mvllow/mellow-site/assets/73542945/30a5e980-fa38-4221-8319-11c552abc6fb)


`flex-wrap` should wrap to the next line when there is no space left:

![image](https://github.com/mvllow/mellow-site/assets/73542945/d1bf562a-12a9-4934-bb10-da3879df652b)